### PR TITLE
Update SysLogininforMapper.xml

### DIFF
--- a/ruoyi-modules/ruoyi-system/src/main/resources/mapper/system/SysLogininforMapper.xml
+++ b/ruoyi-modules/ruoyi-system/src/main/resources/mapper/system/SysLogininforMapper.xml
@@ -9,6 +9,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		<result property="userName"      column="user_name"         />
 		<result property="status"        column="status"            />
 		<result property="ipaddr"        column="ipaddr"            />
+        <result property="loginLocation"        column="login_location"            />
 		<result property="msg"           column="msg"               />
 		<result property="accessTime"    column="access_time"       />
 	</resultMap>


### PR DESCRIPTION
Fixed #2： Column missing in field list

```
## The error occurred while setting parameters
### SQL: INSERT INTO sys_logininfor  ( info_id, user_name, status, ipaddr, login_location, browser, os, msg, login_time )  VALUES  ( ?, ?, ?, ?, ?, ?, ?, ?, ? )
### Cause: java.sql.SQLSyntaxErrorException: Unknown column 'login_location' in 'field list'
; bad SQL grammar []; nested exception is java.sql.SQLSyntaxErrorException: Unknown column 'login_location' in 'field list'
org.springframework.jdbc.BadSqlGrammarException: 
### Error updating database.  Cause: java.sql.SQLSyntaxErrorException: Unknown column 'login_location' in 'field list'
### The error may exist in com/ruoyi/system/mapper/SysLogininforMapper.java (best guess)
### The error may involve com.ruoyi.system.mapper.SysLogininforMapper.insert-Inline
### The error occurred while setting parameters
### SQL: INSERT INTO sys_logininfor  ( info_id, user_name, status, ipaddr, login_location, browser, os, msg, login_time )  VALUES  ( ?, ?, ?, ?, ?, ?, ?, ?, ? )
### Cause: java.sql.SQLSyntaxErrorException: Unknown column 'login_location' in 'field list'
; bad SQL grammar []; nested exception is java.sql.SQLSyntaxErrorException: Unknown column 'login_location' in 'field list'
	at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:239)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:70)
	at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:91)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:441)
	at com.sun.proxy.$Proxy199.insert(Unknown Source)
	at org.mybatis.spring.SqlSessionTemplate.insert(SqlSessionTemplate.java:272)
	at com.baomidou.mybatisplus.core.override.MybatisMapperMethod.execute(MybatisMapperMethod.java:59)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy$PlainMethodInvoker.invoke(MybatisMapperProxy.java:148)
	at com.baomidou.mybatisplus.core.override.MybatisMapperProxy.invoke(MybatisMapperProxy.java:89)
	at com.sun.proxy.$Proxy211.insert(Unknown Source)
	at com.ruoyi.system.service.impl.SysLogininforServiceImpl.insertLogininfor(SysLogininforServiceImpl.java:55)
```