### PR TITLE
update 添加ry-cloud,ry-job,ry-test自动创建数据库的sql语句

### DIFF
--- a/sql/ry-cloud.sql
+++ b/sql/ry-cloud.sql
@@ -1,3 +1,12 @@
+DROP DATABASE IF EXISTS `ry-cloud`;
+
+CREATE DATABASE  `ry-cloud` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+USE `ry-cloud`;
+
 -- ----------------------------
 -- 第三方平台授权表
 -- ----------------------------

--- a/sql/ry-job.sql
+++ b/sql/ry-job.sql
@@ -1,3 +1,12 @@
+DROP DATABASE IF EXISTS `ry-job`;
+
+CREATE DATABASE  `ry-job` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+USE `ry-job`;
+
 -- ----------------------------
 -- Table structure for pj_app_info
 -- ----------------------------

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -1,3 +1,5 @@
+USE `ry-cloud`;
+
 DROP TABLE if EXISTS test_demo;
 CREATE TABLE test_demo
 (


### PR DESCRIPTION
### 更改目的
方便第一次ry-cloud,ry-job数据库的自动创建，test数据的导入
### 改动逻辑
和其他脚本保持一致
### 测试
按照文档顺序导入脚本，能够自动创建数据库，导入数据