### PR TITLE
fix 捕获翻译可能出现的异常，避免翻译报错导致序列化后的结构体变形

### DIFF
--- a/ruoyi-common/ruoyi-common-translation/src/main/java/org/dromara/common/translation/core/handler/TranslationHandler.java
+++ b/ruoyi-common/ruoyi-common-translation/src/main/java/org/dromara/common/translation/core/handler/TranslationHandler.java
@@ -46,8 +46,14 @@ public class TranslationHandler extends JsonSerializer<Object> implements Contex
                 gen.writeNull();
                 return;
             }
-            Object result = trans.translation(value, translation.other());
-            gen.writeObject(result);
+            try {
+                Object result = trans.translation(value, translation.other());
+                gen.writeObject(result);
+            } catch (Exception e) {
+                log.error("翻译处理异常，type: {}, value: {}", translation.type(), value, e);
+                // 出现异常时输出原始值而不是中断序列化
+                gen.writeObject(value);
+            }
         } else {
             gen.writeObject(value);
         }


### PR DESCRIPTION
### 更改目的
框架使用过程中，接口返回响应数据不符合json结构，期望任何时候接口必须返回合法的json数据结构
```
{
    "total": 13,
    "rows": [
        {
            "fileName": "default-bg.png",
            "originalName": "default-bg.png",
            "fileSuffix": "png",
            "url": "http://dev.induschain.cn:9000/nanchen/file/2025/09/0568ba5487c2d29f5fe30b935e.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ff8KcUqwjbvATcEz%2F20250930%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250930T083424Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=da1641ba55707d6e60a27d0cfe31d5f5058bc037e921f2407640aa727fd8a97f",
            "ext1": null,
            "createTime": "2025-09-05 11:09:59",
            "createBy": 1,
            "createByName"
        }
    ]
}{
    "code": 500,
    "msg": "RPC异常，请联系管理员确认",
    "data": null
}
```

### 改动逻辑
排查后发现是翻译时调用异常，导致序列化过程被破坏，进而引发的数据结构体变形。
**改动思路：对翻译逻辑进行异常捕获**
对TranslationHandler的 serialize 方法进行调整
```
       try {
                Object result = trans.translation(value, translation.other());
                gen.writeObject(result);
            } catch (Exception e) {
                log.error("翻译处理异常，type: {}, value: {}", translation.type(), value, e);
                // 出现异常时输出原始值而不是中断序列化
                gen.writeObject(value);
            }
```
### 测试情况
**代码修改前：**
翻译时rpc调用异常，返回数据结构体变形：
![变形](https://github.com/user-attachments/assets/15dff75d-101f-4e64-9b48-c8585a7d2d24)

翻译时逻辑调用正常，返回符合期望的数据结构：
![数据正常响应](https://github.com/user-attachments/assets/842e4304-99cf-4f33-8438-a660f25443bf)

**代码修改后：**
翻译时rpc调用异常时，仍然返回合法数据结构体（完整的json数据结构）：
<img width="1033" height="655" alt="image" src="https://github.com/user-attachments/assets/51733985-05d8-41f2-b228-605659498afa" />


